### PR TITLE
Fix 0-aura tier not showing as gray

### DIFF
--- a/frontend/constants/auraTiers.ts
+++ b/frontend/constants/auraTiers.ts
@@ -14,7 +14,8 @@ export const AURA_TIERS_DESC: AuraTierDef[] = [
   { label: "yellow", color: tailwindColors["aura-yellow"], bg: "#FFFDE7", minPoints: 150 },
   { label: "green", color: tailwindColors["aura-green"], bg: tailwindColors["aura-green-light"], minPoints: 75 },
   { label: "blue", color: tailwindColors["aura-blue"], bg: "#EEF2FF", minPoints: 25 },
-  { label: "purple", color: tailwindColors["aura-purple"], bg: "#F5EEFF", minPoints: 0 },
+  { label: "purple", color: tailwindColors["aura-purple"], bg: "#F5EEFF", minPoints: 1 },
+  { label: "gray", color: tailwindColors["aura-gray"], bg: "#F5F5F5", minPoints: 0 },
 ];
 
 export function getTierForPoints(points: number): AuraTierDef {
@@ -23,7 +24,7 @@ export function getTierForPoints(points: number): AuraTierDef {
 
 /** Next tier floor strictly above `points` (milestones 25 → 75 → 150 → …). Null if already at max. */
 export function getNextAuraThreshold(points: number): number | null {
-  const thresholds = [25, 75, 150, 300, 500];
+  const thresholds = [1, 25, 75, 150, 300, 500];
   const next = thresholds.find((t) => t > points);
   return next ?? null;
 }

--- a/frontend/constants/auraTiers.ts
+++ b/frontend/constants/auraTiers.ts
@@ -15,7 +15,7 @@ export const AURA_TIERS_DESC: AuraTierDef[] = [
   { label: "green", color: tailwindColors["aura-green"], bg: tailwindColors["aura-green-light"], minPoints: 75 },
   { label: "blue", color: tailwindColors["aura-blue"], bg: "#EEF2FF", minPoints: 25 },
   { label: "purple", color: tailwindColors["aura-purple"], bg: "#F5EEFF", minPoints: 1 },
-  { label: "gray", color: tailwindColors["aura-gray"], bg: "#F5F5F5", minPoints: 0 },
+  { label: "gray", color: tailwindColors["aura-black"], bg: "#F5F5F5", minPoints: 0 },
 ];
 
 export function getTierForPoints(points: number): AuraTierDef {


### PR DESCRIPTION
## Developer: Jake Orchanian

## Summary
Fixes 0-aura tier not appearing as gray on Home and Aura pages.

## Modifications
- Changed frontend/constants/auraTiers.ts

## Testing Considerations
- Log into the app with an account with 0 aura
- The progress bar on the Home page and the aura sparkle on the Aura page should be gray

## Checklist
- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows conventions
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

## Screenshots 

| Home | Aura |
| :---: | :---: |
| ![](https://github.com/user-attachments/assets/134e3fe8-24cd-4713-8c62-129e21b359e5) | ![](https://github.com/user-attachments/assets/34bbc908-f154-4106-a52a-895843615799) |



